### PR TITLE
Fix canvas flickering

### DIFF
--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -348,8 +348,13 @@ export default function MockupEditor() {
       const scale = zoom / 100;
       const w = loadedImage.width * scale;
       const h = loadedImage.height * scale;
+      const x = imagePosition.x;
+      const y = imagePosition.y;
 
       ctx.save();
+      ctx.beginPath();
+      ctx.roundRect(x, y, w, h, borderRadius);
+      ctx.clip();
       ctx.globalAlpha = transparency / 100;
       ctx.drawImage(loadedImage, imagePosition.x, imagePosition.y, w, h);
       ctx.restore();

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -316,6 +316,7 @@ export default function MockupEditor() {
     }
 
     requestAnimationFrame(drawCanvas);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     screenSize.width,
     screenSize.height,

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -321,6 +321,7 @@ export default function MockupEditor() {
     isBackgroundLoaded,
     backgroundImage,
     background,
+    borderRadius,
     loadedImage,
     fontWeight,
     fontSize,

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -68,6 +68,10 @@ const defaultSettings = {
 export default function MockupEditor() {
   const [image, setImage] = useState<string | null>(defaultSettings.image);
   const [background, setBackground] = useState(defaultSettings.background);
+  const [loadedImage, setLoadedImage] = useState<HTMLImageElement | null>(null);
+  const [backgroundImage, setBackgroundImage] =
+    useState<HTMLImageElement | null>(null);
+  const [isBackgroundLoaded, setIsBackgroundLoaded] = useState(false);
   const [customColor1, setCustomColor1] = useState(
     defaultSettings.customColor1
   );
@@ -107,11 +111,6 @@ export default function MockupEditor() {
   const [complete, setComplete] = useState(false);
   const [rating, setRating] = useState(0);
   const [comment, setComment] = useState("");
-
-  const [loadedImage, setLoadedImage] = useState<HTMLImageElement | null>(null);
-  const [backgroundImage, setBackgroundImage] =
-    useState<HTMLImageElement | null>(null);
-  const [isBackgroundLoaded, setIsBackgroundLoaded] = useState(false);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const file = acceptedFiles[0];

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -463,11 +463,14 @@ export default function MockupEditor() {
                 <input {...getInputProps()} id="image-upload" />
                 {image ? (
                   <div className="flex items-center justify-center">
-                    <img
-                      src={image}
-                      alt="Uploaded"
-                      className="max-h-24 max-w-full"
-                    />
+                    {
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={image}
+                        alt="Uploaded"
+                        className="max-h-24 max-w-full"
+                      />
+                    }
                     <Button
                       variant="ghost"
                       size="icon"
@@ -551,11 +554,14 @@ export default function MockupEditor() {
                       className="relative aspect-video cursor-pointer overflow-hidden rounded-lg"
                       onClick={() => setBackground(url)}
                     >
-                      <img
-                        src={url}
-                        alt={`Background ${index + 1}`}
-                        className="object-cover w-full h-full"
-                      />
+                      {
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={url}
+                          alt={`Background ${index + 1}`}
+                          className="object-cover w-full h-full"
+                        />
+                      }
                     </div>
                   ))}
                 </TabsContent>

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -262,8 +262,8 @@ export default function MockupEditor() {
 
       img.onload = () => {
         setBackgroundImage(img);
-        setIsBackgroundLoaded(true); // Mark as loaded
-        console.log("Background image loaded");
+        setIsBackgroundLoaded(true);
+        img.setAttribute("crossOrigin", "anonymous");
       };
 
       img.onerror = () => {

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -254,7 +254,6 @@ export default function MockupEditor() {
   }, [updateCanvasScale]);
 
   const backgroundImageRef = useRef(new Image());
-  const [newChangesToDraw, setNewChangesToDraw] = useState(false);
 
   const drawBackgroundImage = (ctx: CanvasRenderingContext2D) => {
     if (background.startsWith("http")) {
@@ -310,10 +309,6 @@ export default function MockupEditor() {
       drawBackgroundImage(ctx);
     }
 
-    if (isDragging || newChangesToDraw) {
-      setNewChangesToDraw(false);
-      requestAnimationFrame(drawCanvas);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     screenSize.width,

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -365,10 +365,6 @@ export default function MockupEditor() {
     }
   };
 
-  useEffect(() => {
-    drawCanvas();
-  }, [drawCanvas]);
-
   const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current;
     if (canvas) {

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -263,7 +263,8 @@ export default function MockupEditor() {
 
       img.onload = () => {
         setBackgroundImage(img);
-        setIsBackgroundLoaded(true);
+        setIsBackgroundLoaded(true); // Mark as loaded
+        console.log("Background image loaded");
       };
 
       img.onerror = () => {
@@ -319,6 +320,7 @@ export default function MockupEditor() {
     screenSize.width,
     screenSize.height,
     isBackgroundLoaded,
+    backgroundImage,
     background,
     loadedImage,
     fontWeight,
@@ -338,7 +340,7 @@ export default function MockupEditor() {
   ]);
 
   useEffect(() => {
-    drawCanvas();
+    drawCanvas(); // Trigger canvas redraw on updates
   }, [drawCanvas]);
 
   const drawImage = (ctx: CanvasRenderingContext2D) => {
@@ -554,7 +556,9 @@ export default function MockupEditor() {
                     <div
                       key={index}
                       className="relative aspect-video cursor-pointer overflow-hidden rounded-lg"
-                      onClick={() => setBackground(url)}
+                      onClick={() => {
+                        setBackground(url);
+                      }}
                     >
                       {
                         // eslint-disable-next-line @next/next/no-img-element

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -307,11 +307,9 @@ export default function MockupEditor() {
     const ctx = canvas?.getContext("2d");
 
     if (canvas && ctx) {
-      // Update canvas dimensions
       canvas.width = screenSize.width;
       canvas.height = screenSize.height;
 
-      // Only draw if the background image is loaded or it's not an image
       drawBackgroundImage(ctx);
     }
 
@@ -354,7 +352,7 @@ export default function MockupEditor() {
       ctx.drawImage(loadedImage, imagePosition.x, imagePosition.y, w, h);
       ctx.restore();
 
-      // Draw shadow if applicable
+      // Draw shadow
       if (shadow > 0) {
         ctx.shadowColor = "rgba(0, 0, 0, 0.5)";
         ctx.shadowBlur = shadow;

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -194,6 +194,7 @@ export default function MockupEditor() {
   const handleClearImage = () => {
     setImage(null);
   };
+
   const handleCloseDialog = () => {
     setComplete(false);
     setRating(0);
@@ -257,24 +258,23 @@ export default function MockupEditor() {
     const ctx = canvas?.getContext("2d");
 
     if (canvas && ctx) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-
       canvas.width = screenSize.width;
       canvas.height = screenSize.height;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear the canvas
 
       // Draw background
       if (background.startsWith("http")) {
         const img = new Image();
         img.setAttribute("crossOrigin", "anonymous");
         img.onload = () => {
-          ctx.save();
-          ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear canvas before drawing
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
           ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-          ctx.restore();
+          drawImage(ctx);
+          drawText(ctx);
         };
         img.src = background;
       } else if (background === "gradient") {
-        ctx.save();
         const gradient = ctx.createLinearGradient(
           0,
           0,
@@ -284,39 +284,19 @@ export default function MockupEditor() {
         gradient.addColorStop(0, customColor1);
         gradient.addColorStop(1, customColor2);
         ctx.fillStyle = gradient;
-        ctx.fillRect(0, 0, canvas.width, canvas.height); // Fill with gradient
-        ctx.restore();
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        drawImage(ctx);
+        drawText(ctx);
       } else {
         ctx.fillStyle = background;
         ctx.fillRect(0, 0, canvas.width, canvas.height);
+        drawImage(ctx);
+        drawText(ctx);
       }
-
-      if (loadedImage) {
-        const scale = zoom / 100;
-        const w = loadedImage.width * scale;
-        const h = loadedImage.height * scale;
-
-        ctx.save();
-        ctx.globalAlpha = transparency / 100;
-        ctx.drawImage(loadedImage, imagePosition.x, imagePosition.y, w, h);
-        ctx.restore();
-
-        // Draw shadow if applicable
-        if (shadow > 0) {
-          ctx.shadowColor = "rgba(0, 0, 0, 0.5)";
-          ctx.shadowBlur = shadow;
-          ctx.shadowOffsetX = 0;
-          ctx.shadowOffsetY = 0;
-          ctx.strokeRect(imagePosition.x, imagePosition.y, w, h);
-        }
-      }
-
-      // Draw text
-      ctx.font = `${fontWeight} ${fontSize}px Arial`;
-      ctx.fillStyle = textColor;
-      ctx.fillText(text, textPosition.x, textPosition.y);
     }
+
     requestAnimationFrame(drawCanvas);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     screenSize.width,
     screenSize.height,
@@ -338,6 +318,39 @@ export default function MockupEditor() {
     shadow,
   ]);
 
+  // Draw the image
+  const drawImage = (ctx: CanvasRenderingContext2D) => {
+    if (loadedImage) {
+      const scale = zoom / 100;
+      const w = loadedImage.width * scale;
+      const h = loadedImage.height * scale;
+
+      ctx.save();
+      ctx.globalAlpha = transparency / 100;
+      ctx.drawImage(loadedImage, imagePosition.x, imagePosition.y, w, h);
+      ctx.restore();
+
+      // Draw shadow if applicable
+      if (shadow > 0) {
+        ctx.shadowColor = "rgba(0, 0, 0, 0.5)";
+        ctx.shadowBlur = shadow;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 0;
+        ctx.strokeRect(imagePosition.x, imagePosition.y, w, h);
+      }
+    }
+  };
+
+  // Draw the text
+  const drawText = (ctx: CanvasRenderingContext2D) => {
+    if (text) {
+      ctx.font = `${fontWeight} ${fontSize}px Arial`;
+      ctx.fillStyle = textColor;
+      ctx.fillText(text, textPosition.x, textPosition.y);
+    }
+  };
+
+  // Trigger drawing on component mount
   useEffect(() => {
     drawCanvas();
   }, [drawCanvas]);


### PR DESCRIPTION
### **Description**
Used `requestAnimationFrame` to handle how often the browser is painting new content, removing the flicker when dragging the uploaded image.

This introduced problems with the `backgroundImage` though, so I've moved that to its own handler and ensured the `backgroundImage` is loaded before redrawing it back onto the canvas because simply using `img.onload` didn't seem to be managing it well enough.

Also tidied up a little bit of related code to reduce lines of code :)

### **Related Issue**
[Canvas flickering issue - 1](https://github.com/suryanshsingh2001/mockly/issues/1)

Closes # 1

### **Changes Made**
- Tidied relevant code (removed stale `console.log`)
- Introduced states for handling image load
- Handled side effects of loading images into canvas using `useEffect`
- Moved drawing of background image to own `fn`

### **Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### **Screenshots (if applicable)**
![Screen Recording 2024-09-27 at 14 18 46](https://github.com/user-attachments/assets/cba3ce58-77b2-4a1f-ae6e-7cb86ffb6df0)

### **How Has This Been Tested?**
- _Manually tested on local environment_

### **Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### **Additional Context**
