### PR TITLE
adding input fields for custom screen size and validations

### DIFF
--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -29,6 +29,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import Header from "@/components/layout/Header";
 import { ShadowManager, type Shadow } from "@/components/shadow-manager";
+import { ScreenSize } from "./types";
+
 
 const backgroundUrls = [
   "https://images.unsplash.com/photo-1557683316-973673baf926?w=1600&h=900&fit=crop",
@@ -88,7 +90,9 @@ export default function MockupEditor() {
   const [gradientAngle, setGradientAngle] = useState(
     defaultSettings.gradientAngle
   );
-  const [screenSize, setScreenSize] = useState(defaultSettings.screenSize);
+  const [screenSize, setScreenSize] = useState<ScreenSize>(defaultSettings.screenSize);
+  const [customScreenSize, setCustomScreenSize] = useState<ScreenSize>(defaultSettings.screenSize);
+  const [presetScreenSize, setPresetScreenSize] = useState(defaultSettings.screenSize);
   const [zoom, setZoom] = useState(defaultSettings.zoom);
   const [transparency, setTransparency] = useState(
     defaultSettings.transparency
@@ -228,6 +232,8 @@ export default function MockupEditor() {
     setCustomColor2(defaultSettings.customColor2);
     setGradientAngle(defaultSettings.gradientAngle);
     setScreenSize(defaultSettings.screenSize);
+    setPresetScreenSize(defaultSettings.screenSize);
+    setCustomScreenSize(defaultSettings.screenSize);
     setZoom(defaultSettings.zoom);
     setTransparency(defaultSettings.transparency);
     setBorderRadius(defaultSettings.borderRadius);
@@ -472,6 +478,23 @@ export default function MockupEditor() {
     return false;
   };
 
+  const handleCustomSizeChange = (key: keyof ScreenSize, value:string) => {
+    const isNumericOrEmpty = /^[0-9]*$/.test(value)
+    if(!isNumericOrEmpty) return;
+
+    const MIN_VALUE = '0'
+    const parsedValue = parseInt(value.length ? value : MIN_VALUE)
+    const size = {...customScreenSize,[key]:parsedValue}
+    setCustomScreenSize(size)
+    setScreenSize(size)
+  }
+
+  const handlePresetSizeChange = (value:string) => {
+    const size = screenSizes[parseInt(value)]
+    setPresetScreenSize(size)
+    setScreenSize(size);
+  }
+
   return (
     <div className="min-h-screen flex flex-col px-6">
       <Header />
@@ -599,15 +622,19 @@ export default function MockupEditor() {
                 </TabsContent>
               </Tabs>
             </div>
-            <div>
+            <div className="w-full">
               <Label htmlFor="screen-size" className="block mb-4">
                 Screen Size
               </Label>
-              <Select
-                onValueChange={(value) =>
-                  setScreenSize(screenSizes[parseInt(value)])
-                }
-                value={screenSizes.indexOf(screenSize).toString()}
+              <Tabs defaultValue="preset" className="w-full">  
+               <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="preset" onClick={() => setScreenSize(presetScreenSize)}>Preset</TabsTrigger>
+                  <TabsTrigger value="custom" onClick={() => setScreenSize(customScreenSize)}>Custom</TabsTrigger>
+                </TabsList>
+                <TabsContent value="preset">
+                <Select
+                onValueChange={(value) => handlePresetSizeChange(value)}
+                value={screenSizes.indexOf(presetScreenSize).toString()}
               >
                 <SelectTrigger id="screen-size">
                   <SelectValue placeholder="Select screen size" />
@@ -620,6 +647,26 @@ export default function MockupEditor() {
                   ))}
                 </SelectContent>
               </Select>
+                </TabsContent>
+                <TabsContent value="custom">
+                  <div className="space-y-2">
+                    <div className="flex space-x-2">
+                      <Input
+                        value={customScreenSize.width}
+                        placeholder="Width"
+                        onChange={(e) => handleCustomSizeChange('width', e.target.value)}
+                        className="w-1/2 h-10"
+                      />
+                      <Input
+                        value={customScreenSize.height}
+                        placeholder="Height"
+                        onChange={(e) => handleCustomSizeChange('height', e.target.value)}
+                        className="w-1/2 h-10"
+                      />
+                    </div>
+                  </div>
+                </TabsContent>
+                </Tabs>
             </div>
 
             <Tabs defaultValue="design" className="w-full">

--- a/components/shared/ValidatedInput.tsx
+++ b/components/shared/ValidatedInput.tsx
@@ -1,0 +1,79 @@
+import { Input } from '@/components/ui/input';
+import React, { useRef, useState } from 'react';
+
+type Props = {
+    onSuccess: (value:number) => void;
+    value:number;
+    className?:string;
+    placeholder:string;
+    setError: (errorMsg:string) => void;
+}
+
+const MIN_VALUE = 200;
+const MAX_VALUE = 2000;
+
+export const ValidatedInput = ({
+    onSuccess, 
+    value : initialValue, 
+    placeholder, 
+    setError, 
+    className = ''
+}:Props) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(`${initialValue}`);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    setError('');
+  };
+
+  const validateInput = () => {
+    const numericValue = Number(value);
+    if (numericValue < MIN_VALUE) {
+        setError(`Value must be greater than ${MIN_VALUE}.`);
+        return false;
+    }
+    if (numericValue > MAX_VALUE) {
+        setError(`Value must be less than ${MAX_VALUE}.`);
+        return false;
+    }
+    return true;
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (!validateInput()) {
+      e.preventDefault();
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      
+      if (!validateInput()) {
+        e.preventDefault();
+      } else {
+        setError('');
+        onSuccess(Number(value))
+      }
+    }
+  };
+
+  return (
+      <Input
+        type="number"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        ref={inputRef}
+        placeholder={placeholder}
+        className={className}
+      />
+
+  );
+};
+
+export default ValidatedInput;

--- a/components/shared/ValidatedInput.tsx
+++ b/components/shared/ValidatedInput.tsx
@@ -1,62 +1,57 @@
 import { Input } from '@/components/ui/input';
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
+import { validateInput } from './utils';
 
 type Props = {
-    onSuccess: (value:number) => void;
-    value:number;
+    value: string;
+    setValue: React.Dispatch<React.SetStateAction<string>>
     className?:string;
     placeholder:string;
-    setError: (errorMsg:string) => void;
+    onSuccess: () => void;
+    setError: (errorMsg: string) => void;
 }
 
-const MIN_VALUE = 200;
-const MAX_VALUE = 2000;
-
-export const ValidatedInput = ({
+export default function ValidatedInput ({
     onSuccess, 
-    value : initialValue, 
+    value,
+    setValue, 
     placeholder, 
     setError, 
     className = ''
-}:Props) => {
+}:Props) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [value, setValue] = useState(`${initialValue}`);
+
+  const handleSubmit = () => {
+    setError('');
+    onSuccess()
+  }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
     setError('');
   };
 
-  const validateInput = () => {
-    const numericValue = Number(value);
-    if (numericValue < MIN_VALUE) {
-        setError(`Value must be greater than ${MIN_VALUE}.`);
-        return false;
-    }
-    if (numericValue > MAX_VALUE) {
-        setError(`Value must be less than ${MAX_VALUE}.`);
-        return false;
-    }
-    return true;
-  }
-
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (!validateInput()) {
+     const {success, errorMsg} = validateInput(value)
+     if (!success) {
+      setError(errorMsg)
       e.preventDefault();
       if (inputRef.current) {
         inputRef.current.focus();
       }
+    } else {
+        handleSubmit()
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      
-      if (!validateInput()) {
+      const {success, errorMsg} = validateInput(value)
+      if (!success) {
+        setError(errorMsg)
         e.preventDefault();
       } else {
-        setError('');
-        onSuccess(Number(value))
+        handleSubmit()
       }
     }
   };
@@ -76,4 +71,3 @@ export const ValidatedInput = ({
   );
 };
 
-export default ValidatedInput;

--- a/components/shared/types.ts
+++ b/components/shared/types.ts
@@ -1,0 +1,4 @@
+export type ScreenSize = {
+    height:number;
+    width:number
+}

--- a/components/shared/types.ts
+++ b/components/shared/types.ts
@@ -2,3 +2,8 @@ export type ScreenSize = {
     height:number;
     width:number
 }
+
+export type ValidationError = {
+    customHeight:string;
+    customWidth:string
+}

--- a/components/shared/utils.ts
+++ b/components/shared/utils.ts
@@ -1,0 +1,22 @@
+const MIN_SCREEN_SIZE  = 200;
+const MAX_SCREEN_SIZE = 2000;
+
+export const validateInput = (value: string) => {
+    const numericValue = Number(value);
+    if (numericValue < MIN_SCREEN_SIZE) {
+        return {
+          success: false,
+          errorMsg: `Value must be greater than ${MIN_SCREEN_SIZE}.`
+        };
+    }
+    if (numericValue > MAX_SCREEN_SIZE) {
+      return {
+        success: false,
+        errorMsg: `Value must be less than ${MAX_SCREEN_SIZE}.`
+      };
+    }
+    return {
+      success: true, 
+      errorMsg: ''
+    };
+}

--- a/components/shared/utils.ts
+++ b/components/shared/utils.ts
@@ -1,5 +1,5 @@
 const MIN_SCREEN_SIZE  = 200;
-const MAX_SCREEN_SIZE = 2000;
+const MAX_SCREEN_SIZE = 2160;
 
 export const validateInput = (value: string) => {
     const numericValue = Number(value);


### PR DESCRIPTION
## Pull Request Template

### **Description**
This PR adds a feature for passing custom screen sizes.

### **Related Issue**
https://github.com/suryanshsingh2001/mockly/issues/4

Closes # (issue)
https://github.com/suryanshsingh2001/mockly/issues/4

### **Changes Made**
1.) Implemented separate state variables to manage the dimensions of "customScreenSize" and "presetScreenSize". This allows for better tracking and control over the values for each screen size type.
2.) Updated the "screenSize" state based on the currently active tab, either "custom" or "preset". This ensures that the displayed screen size reflects the user's selection accurately.
3.) Added "handleCustomSizeChange" function to validate input for "customScreenSize". The validation allows only positive numerical values, ensuring data integrity and preventing invalid entries.

### **Type of Change**
_Select the type of change made with this pull request:_

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### **Screenshots (if applicable)**

https://github.com/user-attachments/assets/3c418488-1d7d-46c2-91ae-a8e62771812d





### **How Has This Been Tested?**
- _Manually tested on local environment_

### **Checklist**
_Check off the following items before submitting the pull request:_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

