### PR TITLE
moving padding-x from body to individual pages for better stability

### DIFF
--- a/app/(public)/privacy/page.tsx
+++ b/app/(public)/privacy/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 
 export default function PrivacyPolicy() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background px-6">
       <div className="container mx-auto px-4 md:px-6 py-12">
         <h1 className="text-3xl font-bold mb-6 text-center">Privacy Policy</h1>
         <div className="prose prose-sm max-w-none dark:prose-invert">

--- a/app/(public)/terms/page.tsx
+++ b/app/(public)/terms/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 
 export default function TermsOfService() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background px-6">
       <div className="container mx-auto px-4 md:px-6 py-12">
         <h1 className="text-3xl font-bold mb-6 text-center">Terms of Service</h1>
         <div className="prose prose-sm max-w-none dark:prose-invert">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <head />
         <body
           className={cn(
-            "min-h-screen bg-background font-sans antialiased px-6",
+            "min-h-screen bg-background font-sans antialiased",
            fontSans.variable
           )}
         >

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="min-h-screen flex items-center justify-center bg-background px-6">
       <div className="max-w-md w-full px-4 py-8 text-center">
         <div className="mb-8">
           <Search className="mx-auto h-12 w-12 text-primary" />

--- a/components/layout/LandingPage.tsx
+++ b/components/layout/LandingPage.tsx
@@ -35,7 +35,7 @@ import { Badge } from "../ui/badge";
 
 export default function LandingPage() {
   return (
-    <div className="flex flex-col min-h-screen bg-background text-foreground">
+    <div className="flex flex-col min-h-screen bg-background text-foreground px-6">
       <LandingHeader />
 
       <main className="flex-1 pt-16">

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -473,7 +473,7 @@ export default function MockupEditor() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col px-6">
       <Header />
       <main className="container mx-auto">
         <div className="flex flex-col lg:flex-row gap-8">

--- a/components/shared/NotAvailable.tsx
+++ b/components/shared/NotAvailable.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 
 export default function NotAvailable() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="min-h-screen flex items-center justify-center bg-background px-6">
       <div className="max-w-md w-full px-4 py-8 text-center">
         <div className="mb-8">
           <AlertTriangle className="mx-auto h-12 w-12 text-yellow-500" />


### PR DESCRIPTION
### **Description**
Moved padding-x from body to individual pages for better stability during scroll-lock events.

### **Related Issue**
https://github.com/suryanshsingh2001/mockly/issues/6

### **Changes Made**
1. Removed px-6 from the body element
2. Added px-6 to the main parent elements of individual pages

### **Type of Change**
_Select the type of change made with this pull request:_

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### **How Has This Been Tested?**
1. Go to "Editor" page
2. Click the select box to choose the screen size
3. See the screen not shifting

### **Checklist**
_Check off the following items before submitting the pull request:_

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
