### PR TITLE
Fix/removing NaN for shadow

### DIFF
--- a/components/shadow-manager.tsx
+++ b/components/shadow-manager.tsx
@@ -54,7 +54,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
     const updatedShadow = {
       ...shadowValue, 
       x: shadowValue.x ? shadowValue.x : 0,
-      y: shadowValue.y > 0 ? shadowValue.y : 0, 
+      y: shadowValue.y ? shadowValue.y : 0, 
       blur: shadowValue.blur ? shadowValue.blur : 0 
     }
     setShadowValue(updatedShadow);
@@ -144,6 +144,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
             id="blur"
             type="number"
             className="col-span-3"
+            min={0}
             value={shadowValue.blur}
             onChange={(e) => {
               const newValue = parseInt(e.target.value);

--- a/components/shadow-manager.tsx
+++ b/components/shadow-manager.tsx
@@ -16,21 +16,16 @@ export type Shadow = {
 };
 
 interface ShadowManagerProps {
-  value: Shadow;
-  onChange: (value: Shadow) => void;
+  shadowValue: Shadow;
+  setShadowValue: React.Dispatch<React.SetStateAction<Shadow>>
 }
 
 export const ShadowManager: React.FC<ShadowManagerProps> = ({
-  value,
-  onChange,
+  shadowValue,
+  setShadowValue,
 }) => {
   const [popoverVisible, setPopoverVisible] = useState(false);
-  const [shadowValue, setShadowValue] = useState<Shadow>(value);
   const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    setShadowValue(value);
-  }, [value]);
 
   const handleInputChange = (newValues: Partial<Shadow>) => {
     const updatedShadow = {
@@ -40,7 +35,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
       blur: shadowValue.blur,
       ...newValues,
     };
-    onChange(updatedShadow);
+    setShadowValue(updatedShadow);
   };
 
   useEffect(() => {
@@ -54,6 +49,16 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
       window.removeEventListener("resize", handleResize);
     };
   }, []);
+
+  const handleBlur = () => {
+    const updatedShadow = {
+      ...shadowValue, 
+      x: shadowValue.x ? shadowValue.x : 0,
+      y: shadowValue.y > 0 ? shadowValue.y : 0, 
+      blur: shadowValue.blur ? shadowValue.blur : 0 
+    }
+    setShadowValue(updatedShadow);
+  }
 
   return (
     <Popover open={popoverVisible} onOpenChange={setPopoverVisible}>
@@ -107,6 +112,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
               setShadowValue({ ...shadowValue, x: newValue });
               handleInputChange({ x: newValue });
             }}
+            onBlur={handleBlur}
           />
 
           <Label
@@ -125,6 +131,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
               setShadowValue({ ...shadowValue, y: newValue });
               handleInputChange({ y: newValue });
             }}
+            onBlur={handleBlur}
           />
 
           <Label
@@ -143,6 +150,7 @@ export const ShadowManager: React.FC<ShadowManagerProps> = ({
               setShadowValue({ ...shadowValue, blur: newValue });
               handleInputChange({ blur: newValue });
             }}
+            onBlur={handleBlur}
           />
         </div>
       </PopoverContent>

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -746,8 +746,8 @@ export default function MockupEditor() {
                   <div className="flex items-center justify-between">
                     <Label htmlFor="shadow">Shadow: {shadow.blur ? shadow.blur : 0}px</Label>
                     <ShadowManager
-                      value={shadow}
-                      onChange={(value) => setShadow(value)}
+                      shadowValue={shadow}
+                      setShadowValue={setShadow}
                     />
                   </div>
                   <Slider

--- a/components/shared/Editor.tsx
+++ b/components/shared/Editor.tsx
@@ -744,7 +744,7 @@ export default function MockupEditor() {
                 </div>
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
-                    <Label htmlFor="shadow">Shadow: {shadow.blur}px</Label>
+                    <Label htmlFor="shadow">Shadow: {shadow.blur ? shadow.blur : 0}px</Label>
                     <ShadowManager
                       value={shadow}
                       onChange={(value) => setShadow(value)}


### PR DESCRIPTION
## Pull Request Template

### **Description**
This PR addresses the issue where clearing the Blur property in the Shadow settings results in "NaN" being displayed on the UI. It is essential to handle this case appropriately to improve the user experience and ensure that "NaN" is not shown to the users.



Closes https://github.com/suryanshsingh2001/mockly/issues/23

### **Changes Made**

- Updated the ShadowManager component to validate and set default values for shadowX, shadowY, and blur properties on blur events.

### **Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### **Screenshots**
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/2f9458d9-c342-4d66-86a5-16c0d9bf6636">

### **How Has This Been Tested?**

- _Manually tested on local environment_

### **Checklist**
_Check off the following items before submitting the pull request:_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
